### PR TITLE
Make Junit test-scoped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>
+        <scope>test</scope>
     </dependency>     
   </dependencies>  
 </project>


### PR DESCRIPTION
Junit is currently deployed to Maven Central with scope `compile`, which isn't necessary and requires end users to exclude it as a transitive dependency. It's also licensed under EPL, which could confuse people who see that mjson is licensed under Apache 2.