### PR TITLE
Update Object to use LinkedHashMap rather than HashMap

### DIFF
--- a/src/java/mjson/Json.java
+++ b/src/java/mjson/Json.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1075,7 +1076,7 @@ public class Json implements java.io.Serializable, Iterable<Json>
     			this.theschema = expandReferences(this.theschema, 
     											  this.theschema, 
     											  this.uri, 
-    											  new HashMap<String, Json>(), 
+    											  new LinkedHashMap<String, Json>(), 
     											  new IdentityHashMap<Json, Json>(),
     											  relativeReferenceResolver);
     		}
@@ -2347,7 +2348,7 @@ public class Json implements java.io.Serializable, Iterable<Json>
 	{
 		private static final long serialVersionUID = 1L;
 		
-		Map<String, Json> object = new HashMap<String, Json>();
+		Map<String, Json> object = new LinkedHashMap<String, Json>();
 
 		@Override
 		public Iterator<Json> iterator() {
@@ -2460,7 +2461,7 @@ public class Json implements java.io.Serializable, Iterable<Json>
 		public boolean isObject() { return true; }
 		public Map<String, Object> asMap() 
 		{
-			HashMap<String, Object> m = new HashMap<String, Object>();
+			HashMap<String, Object> m = new LinkedHashMap<String, Object>();
 			for (Map.Entry<String, Json> e : object.entrySet())
 				m.put(e.getKey(), e.getValue().getValue());
 			return m; 


### PR DESCRIPTION
Updated `HashMap` usages to use `LinkedHashMap` to preserve order of key insertion in Objects.

AFAIK this is not part of the spec yet makes the behavior consistent with other JSON parsers: [1](https://github.com/FasterXML/jackson-databind/blob/62c9d3dfe4b512380fdb7cfb38f6f9a0204f0c1a/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java#L30) [2](https://github.com/lihaoyi/upickle/blob/95594400d220bb3b16c8fb7558ca8c598112490b/ujson/src/ujson/Value.scala#L235) [3](https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/JsonObject.java#L33) [4](https://github.com/jsonp/jsonp/blob/master/jsonp-impl/src/main/java/com/alibaba/json/JsonObjectImpl.java#L22)